### PR TITLE
Revert fix

### DIFF
--- a/apps/fanfares/src/app/components/Navbar.tsx
+++ b/apps/fanfares/src/app/components/Navbar.tsx
@@ -53,7 +53,7 @@ export function Navbar() {
     const el = document.getElementById('main-content-container-element') // can we do this in a more reacty way?
     if (el) {
       if (nav && nav.current) {
-        el.classList.remove('h-screen')
+        //el.classList.remove('h-screen')
         el.style.height = `calc(${nav.current.offsetTop - el.offsetTop}px)`
       }
     }

--- a/apps/fanfares/src/app/components/Navbar.tsx
+++ b/apps/fanfares/src/app/components/Navbar.tsx
@@ -54,7 +54,7 @@ export function Navbar() {
     if (el) {
       if (nav && nav.current) {
         //el.classList.remove('h-screen')
-        el.style.height = `calc(${nav.current.offsetTop - el.offsetTop}px)`
+        //el.style.height = `calc(${nav.current.offsetTop - el.offsetTop}px)`
       }
     }
   })


### PR DESCRIPTION
The fix caused a problem in which the top headers were covered when navigating from a scrolled page. Weird.